### PR TITLE
Load "cl" package without "eval-when-compile" (Closes: #27)

### DIFF
--- a/ace-jump-mode.el
+++ b/ace-jump-mode.el
@@ -92,8 +92,7 @@
 
 ;;; Code:
 
-(eval-when-compile
-  (require 'cl))
+(require 'cl)
 
 ;;;; ============================================
 ;;;; Utilities for ace-jump-mode


### PR DESCRIPTION
The problem is basically that e.g. `every` is just an alias for `cl-every` and these aliases seems to be no longer known when using `eval-when-compile`. So there are two possible solutions:
1. Require **cl** without using `eval-when-compile` (this pull request)
2. Refactoring the whole package to use the proper function names e.g.
   - `every` → `cl-every`
   - `position` → `cl-position`
   - […]

Since a lot of other package already requiring **cl** in this way, it seems to be legit.
