### PR TITLE
`ace-jump-update-overlay-in-search-tree': Add paddings for wide-characters

### DIFF
--- a/ace-jump-mode.el
+++ b/ace-jump-mode.el
@@ -516,7 +516,9 @@ node and call LEAF-FUNC on each leaf node"
                                   ((string-equal subs "\n")
                                    "\n")
                                   (t
-                                   "")))))))))
+                                   ;; there are wide-width characters
+                                   ;; so, we need paddings
+                                   (make-string (1- (string-width subs)) ? ))))))))))
     (loop for k in keys
           for n in (cdr tree)
           do (progn


### PR DESCRIPTION
In CJK, we use wide characters.
We need pad string for wide characters.

You can check it by `C-h h M-x ace-jump-word-mode'
