### PR TITLE
Add `ace-jump-search-filter' variable

### DIFF
--- a/ace-jump-mode.el
+++ b/ace-jump-mode.el
@@ -284,6 +284,10 @@ jump internal use.  If you want to change it, use
 `ace-jump-mode-enable-mark-sync' or
 `ace-jump-mode-disable-mark-sync'.")
 
+(defvar ace-jump-search-filter nil
+  "This should be nil or a point-dependant predicate
+that `ace-jump-search-candidate' will use as an additional filter.")
+
 (defgroup ace-jump nil
   "ace jump group"
   :group 'convenience)
@@ -371,7 +375,10 @@ The returned value is a list of `aj-position' record."
                              until (or
                                     (> (point) end-point)
                                     (eobp))
-                             if (or ace-jump-allow-invisible (not (invisible-p (match-beginning 0))))
+                          if (and (or ace-jump-allow-invisible (not (invisible-p (match-beginning 0))))
+                                  (or (null ace-jump-search-filter)
+                                      (ignore-errors
+                                        (funcall ace-jump-search-filter))))
                              collect (make-aj-position :offset (match-beginning 0)
                                                        :visual-area va)
                              ;; when we use "^" to search line mode,


### PR DESCRIPTION
- ace-jump-mode.el (ace-jump-search-candidate): uses
  `ace-jump-search-filter' if it's not nil

Hi,

This addition might be useful for package writers that use ace-jump-mode.

Here's a use-case for this (jump to open paren but not in comment or string):

```
(let ((ace-jump-search-filter (lambda() (not (in-string-or-comment-p)))))
      (ace-jump-char-mode ?\()))
```
