### PR TITLE
Force `window-end' to update when creating background for visual area

### DIFF
--- a/ace-jump-mode.el
+++ b/ace-jump-mode.el
@@ -602,7 +602,7 @@ You can constrol whether use the case sensitive via `ace-jump-mode-case-fold'.
                       collect (let* ((w (aj-visual-area-window va))
                                      (b (aj-visual-area-buffer va))
                                      (ol (make-overlay (window-start w)
-                                                       (window-end w)
+                                                       (window-end w t)
                                                        b)))
                                 (overlay-put ol 'face 'ace-jump-face-background)
                                 ol))))


### PR DESCRIPTION
When using `heml-M-x` to call the `ace-jump-line-mode` command, the helm window will occupy some space of the original window, so calling `window-end` without setting the UPDATE to be t might not reflect the real end point of the original window, which makes the created overlay of the gray background doesn't cover all the area after the helm window disappears. Forcing the UPDATE parameter to t when calling the `window-end' would solve the problem.

Actually in `ace-jump-search-candidate`, we set the UPDATE to `t` in `(end-point   (window-end   current-window t))`(see https://github.com/winterTTr/ace-jump-mode/blob/master/ace-jump-mode.el#L361) and when making the overlay for the background, we should also do the same.
