### PR TITLE
Correct use of eval-after-load

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ How to install it?
       "ace-jump-mode"
       "Ace jump back:-)"
       t)
-    (eval-after-load "ace-jump-mode"
+    (eval-after-load 'ace-jump-mode
       '(ace-jump-mode-enable-mark-sync))
     (define-key global-map (kbd "C-x SPC") 'ace-jump-mode-pop-mark)
     

--- a/ace-jump-mode.el
+++ b/ace-jump-mode.el
@@ -76,7 +76,7 @@
 ;;   "ace-jump-mode"
 ;;   "Ace jump back:-)"
 ;;   t)
-;; (eval-after-load "ace-jump-mode"
+;; (eval-after-load 'ace-jump-mode
 ;;   '(ace-jump-mode-enable-mark-sync))
 ;; (define-key global-map (kbd "C-x SPC") 'ace-jump-mode-pop-mark)
 ;; 


### PR DESCRIPTION
With a symbol, only the file providing the feature triggers the eval-after-load.
With a string, any file named the same way triggers it.