### PR TITLE
fix "Package cl is deprecated" warning

### DIFF
--- a/ace-jump-mode.el
+++ b/ace-jump-mode.el
@@ -92,7 +92,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 ;;;; ============================================
 ;;;; Utilities for ace-jump-mode
@@ -103,7 +103,7 @@
 ;; ---------------------
 
 ;; make a position in a visual area
-(defstruct aj-position offset visual-area)
+(cl-defstruct aj-position offset visual-area)
 
 (defmacro aj-position-buffer (aj-pos)
   "Get the buffer object from `aj-position'."
@@ -128,13 +128,13 @@
 
 ;; a record for all the possible visual area
 ;; a visual area is a window that showing some buffer in some frame.
-(defstruct aj-visual-area buffer window frame recover-buffer)
+(cl-defstruct aj-visual-area buffer window frame recover-buffer)
 
 
 ;; ---------------------
 ;; a FIFO queue implementation
 ;; ---------------------
-(defstruct aj-queue head tail)
+(cl-defstruct aj-queue head tail)
 
 (defun aj-queue-push (item q)
   "enqueue"
@@ -240,8 +240,8 @@ Currently, the valid submode is:
 ")
 
 (defvar ace-jump-mode-move-keys
-  (nconc (loop for i from ?a to ?z collect i)
-         (loop for i from ?A to ?Z collect i))
+  (nconc (cl-loop for i from ?a to ?z collect i)
+         (cl-loop for i from ?A to ?Z collect i))
   "*The keys that used to move when enter AceJump mode.
 Each key should only an printable character, whose name will
 fill each possible location.
@@ -355,7 +355,7 @@ You can control whether use the case sensitive or not by `ace-jump-mode-case-fol
 
 Every possible `match-beginning' will be collected.
 The returned value is a list of `aj-position' record."
-  (loop for va in visual-area-list
+  (cl-loop for va in visual-area-list
         append (let* ((current-window (aj-visual-area-window va))
                       (start-point (window-start current-window))
                       (end-point   (window-end   current-window t)))
@@ -363,7 +363,7 @@ The returned value is a list of `aj-position' record."
                    (save-excursion
                      (goto-char start-point)
                      (let ((case-fold-search ace-jump-mode-case-fold))
-                       (loop while (re-search-forward re-query-string nil t)
+                       (cl-loop while (re-search-forward re-query-string nil t)
                              until (or
                                     (> (point) end-point)
                                     (eobp))
@@ -404,7 +404,7 @@ while a child node list when type is 'branch"
           ;; current child can fill the left leaf
           (progn
             (setf (cdr node)
-                  (loop for i from 1 to left-leaf-node
+                  (cl-loop for i from 1 to left-leaf-node
                         collect (cons 'leaf nil)))
             ;; so this should be the last action for while
             (setq left-leaf-node 0))
@@ -413,7 +413,7 @@ while a child node list when type is 'branch"
           ;; fill as much as possible. Push them to queue, so it have
           ;; the oppotunity to become 'branch node if necessary
           (setf (cdr node)
-                (loop for i from 1 to max-child-node
+                (cl-loop for i from 1 to max-child-node
                       collect (let ((n (cons 'leaf nil)))
                                 (aj-queue-push n q)
                                 n)))
@@ -523,7 +523,7 @@ node and call LEAF-FUNC on each leaf node"
                                    ;; there are wide-width characters
                                    ;; so, we need paddings
                                    (make-string (max 0 (1- (string-width subs))) ? ))))))))))
-    (loop for k in keys
+    (cl-loop for k in keys
           for n in (cdr tree)
           do (progn
                ;; update "key" variable so that the function can use
@@ -540,20 +540,20 @@ node and call LEAF-FUNC on each leaf node"
   "Based on `ace-jump-mode-scope', search the possible buffers that is showing now."
   (cond
    ((eq ace-jump-mode-scope 'global)
-    (loop for f in (frame-list)
-          append (loop for w in (window-list f)
+    (cl-loop for f in (frame-list)
+          append (cl-loop for w in (window-list f)
                        collect (make-aj-visual-area :buffer (window-buffer w)
                                                     :window w
                                                     :frame f))))
    ((eq ace-jump-mode-scope 'visible)
-    (loop for f in (frame-list)
+    (cl-loop for f in (frame-list)
           if (eq t (frame-visible-p f))
-          append (loop for w in (window-list f)
+          append (cl-loop for w in (window-list f)
                        collect (make-aj-visual-area :buffer (window-buffer w)
                                                     :window w
                                                     :frame f))))
    ((eq ace-jump-mode-scope 'frame)
-    (loop for w in (window-list (selected-frame))
+    (cl-loop for w in (window-list (selected-frame))
           collect (make-aj-visual-area :buffer (window-buffer w)
                                        :window w
                                        :frame (selected-frame))))
@@ -598,7 +598,7 @@ You can constrol whether use the case sensitive via `ace-jump-mode-case-fold'.
       ;; create background for each visual area
       (if ace-jump-mode-gray-background
           (setq ace-jump-background-overlay-list
-                (loop for va in visual-area-list
+                (cl-loop for va in visual-area-list
                       collect (let* ((w (aj-visual-area-window va))
                                      (b (aj-visual-area-buffer va))
                                      (ol (make-overlay (window-start w)
@@ -947,7 +947,7 @@ You can constrol whether use the case sensitive via
   (force-mode-line-update)
 
   ;; delete background overlay
-  (loop for ol in ace-jump-background-overlay-list
+  (cl-loop for ol in ace-jump-background-overlay-list
         do (delete-overlay ol))
   (setq ace-jump-background-overlay-list nil)
 
@@ -981,7 +981,7 @@ PRED is a function object which can pass to funcall and accept
 one argument, which will be every element in the list.
 Such as : (lambda (x) (equal x 1)) "
   (let (true-list false-list)
-    (loop for e in l
+    (cl-loop for e in l
           do (if (funcall pred e)
                  (setq true-list (cons e true-list))
                (setq false-list (cons e false-list))))


### PR DESCRIPTION
cl-lib was published many years ago as a better alternative to cl. And in Emacs-27 cl now has a deprecation warning. Replace `(require 'cl)` with `(require cl-lib)` will fix it.